### PR TITLE
Client to Server Synchronization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(client
     client/Connection.cpp
     client/ClientMonitor.cpp
     client/ServerMonitor.cpp
+    client/ClientState.cpp
 )
 
 target_include_directories(server PUBLIC common)

--- a/client/ClientMonitor.cpp
+++ b/client/ClientMonitor.cpp
@@ -1,9 +1,17 @@
 #include <memory>
-#include <unistd.h>
+#include <iostream>
+#include <fcntl.h>
+#include <sys/unistd.h>
+#include <sys/inotify.h>
 
 #include "ClientMonitor.hpp"
 #include "ClientState.hpp"
+#include "FileOp.hpp"
 #include "Connection.hpp"
+
+#define MAX_EVENT_SIZE (sizeof(struct inotify_event) + 256)
+#define MAX_EVENTS 10
+#define EVENT_BUF_LEN (MAX_EVENT_SIZE * MAX_EVENTS)
 
 ClientMonitor::ClientMonitor(std::shared_ptr<ClientState> clientState,
         std::shared_ptr<Connection> connection) {
@@ -11,9 +19,44 @@ ClientMonitor::ClientMonitor(std::shared_ptr<ClientState> clientState,
     this->connection = connection;
 }
 
-void ClientMonitor::run() {
-    while (*clientState == ClientState::STATE_ACTIVE) {
-        // TODO
+void ClientMonitor::run(std::string sync_dir) {
+    int inotifyFd, watchFd, flags, bytesRead;
+    unsigned char buffer[EVENT_BUF_LEN];
+
+    inotifyFd = inotify_init();
+
+    if (inotifyFd < 0) {
+        std::cerr << "Couldn't open inotify file" << std::endl;
+        return;
+    }
+
+    watchFd = inotify_add_watch(inotifyFd, sync_dir.c_str(),
+            IN_CLOSE_WRITE | IN_DELETE | IN_DELETE_SELF | IN_MOVED_FROM | IN_MOVED_TO);
+
+    if (watchFd == -1) {
+        std::cerr << "Couldn't add inotify watch" << std::endl;
+        return;
+    }
+
+    flags = fcntl(inotifyFd, F_GETFL, 0);
+    fcntl(inotifyFd, F_SETFL, flags | O_NONBLOCK);
+
+    while (clientState->get() == AppState::STATE_ACTIVE) {
+        bytesRead = read(inotifyFd, buffer, EVENT_BUF_LEN); 
+
+        if (bytesRead > 0) {
+            unsigned char *eventPtr = buffer;
+            while (eventPtr < buffer + bytesRead) {
+                inotify_event *event = (inotify_event*) eventPtr;
+                if (event->mask & IN_CLOSE_WRITE || event->mask & IN_MOVED_TO)
+                    connection->syncWrite(FileOp::OP_CHANGE, event->name, event->name);
+                if (event->mask & IN_DELETE || event->mask & IN_MOVED_FROM)
+                    connection->syncWrite(FileOp::OP_DELETE, event->name, event->name);
+                if (event->mask & IN_DELETE_SELF)
+                    clientState->set(AppState::STATE_UNTRACKED);
+                eventPtr += sizeof(inotify_event) + event->len;
+            }
+        }
     }
 }
 

--- a/client/ClientMonitor.hpp
+++ b/client/ClientMonitor.hpp
@@ -2,6 +2,7 @@
 #define CLIENT_MONITOR_H
 
 #include <memory>
+#include <string>
 
 #include "ClientState.hpp"
 #include "Connection.hpp"
@@ -13,7 +14,7 @@ class ClientMonitor {
 public:
     ClientMonitor(std::shared_ptr<ClientState> clientState,
             std::shared_ptr<Connection> connection);
-    void run();
+    void run(std::string sync_dir);
 };
 
 #endif

--- a/client/ClientState.cpp
+++ b/client/ClientState.cpp
@@ -1,0 +1,39 @@
+#include "ClientState.hpp"
+
+ClientState::ClientState(AppState state) {
+    sem_init(&mutex, 0, 1);
+    sem_init(&rw, 0, 1);
+    this->readCount = 0;
+    this->state = state;
+}
+
+ClientState::~ClientState() {
+    sem_destroy(&mutex);
+    sem_destroy(&rw);
+}
+
+AppState ClientState::get() {
+    AppState state;
+
+    sem_wait(&mutex);
+    readCount++;
+    if (readCount == 1)
+        sem_wait(&rw);
+    sem_post(&mutex);
+
+    state = this->state;
+
+    sem_wait(&mutex);
+    readCount--;
+    if (readCount == 0)
+        sem_post(&rw);
+    sem_post(&mutex);
+
+    return state;
+}
+
+void ClientState::set(AppState state) {
+    sem_wait(&rw);
+    this->state = state;
+    sem_post(&rw);
+}

--- a/client/ClientState.hpp
+++ b/client/ClientState.hpp
@@ -1,9 +1,24 @@
 #ifndef CLIENT_STATE_H
 #define CLIENT_STATE_H
 
-enum class ClientState {
+#include <semaphore.h>
+
+enum class AppState {
     STATE_ACTIVE,
+    STATE_UNTRACKED,
     STATE_CLOSING
+};
+
+class ClientState {
+    sem_t mutex;
+    sem_t rw;
+    int readCount;
+    AppState state;
+public:
+    ClientState(AppState state);
+    ~ClientState();
+    AppState get();
+    void set(AppState state);
 };
 
 #endif

--- a/client/Connection.cpp
+++ b/client/Connection.cpp
@@ -1,7 +1,7 @@
 #include <string>
-
 #include <vector>
 
+#include "FileOp.hpp"
 #include "Connection.hpp"
 
 void Connection::connectToServer(std::string username, std::string ip, int port) {
@@ -23,4 +23,17 @@ void Connection::delete_(std::string filepath) {
 std::vector<FileMetadata> Connection::listServer() {
     // TODO
     return std::vector<FileMetadata>();
+}
+
+void Connection::syncWrite(FileOp op, std::string ogFilename, std::string newFilename) {
+    switch (op) {
+        case FileOp::OP_CHANGE:
+            // TODO
+            break;
+        case FileOp::OP_DELETE:
+            // TODO
+            break;
+        default:
+            break;
+    }
 }

--- a/client/Connection.hpp
+++ b/client/Connection.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "FileMetadata.hpp"
+#include "FileOp.hpp"
 
 class Connection {
 public:
@@ -13,6 +14,7 @@ public:
     void download(std::string filepath);
     void delete_(std::string filepath);
     std::vector<FileMetadata> listServer();
+    void syncWrite(FileOp op, std::string ogFilename, std::string newFilename);
 };
 
 #endif

--- a/client/FileOp.hpp
+++ b/client/FileOp.hpp
@@ -1,0 +1,9 @@
+#ifndef FILE_OP_H
+#define FILE_OP_H
+
+enum class FileOp {
+    OP_CHANGE,
+    OP_DELETE
+};
+
+#endif

--- a/client/ServerMonitor.cpp
+++ b/client/ServerMonitor.cpp
@@ -12,7 +12,7 @@ ServerMonitor::ServerMonitor(std::shared_ptr<ClientState> clientState,
 }
 
 void ServerMonitor::run() {
-    while (*clientState == ClientState::STATE_ACTIVE) {
+    while (clientState->get() == AppState::STATE_ACTIVE) {
         // TODO
     }
 }


### PR DESCRIPTION
This PR implements methods responsible for client to server sinchronization. Some adjustments had to be done regarding the original project.

Firstly, the connection operation OP_MOVE had to be dismissed, in favor of successive OP_REMOVE and OP_CHANGE operations, as it more closely resembled inotify signals, thus greatly simplifying business logic.

Secondly, ClientState became a standard class, instead of an enum class, so as to allow proper getter and setter methods to coordinate concurrent access.