### PR TITLE
Correções da etapa 1

### DIFF
--- a/client/CLI.cpp
+++ b/client/CLI.cpp
@@ -13,7 +13,9 @@ void CLI::run(std::string username, std::string ip, int port) {
     bool newLine;
     struct pollfd cinFd;
 
-    makeConnection(username, ip, port);
+    if (!makeConnection(username, ip, port)) {
+        return;
+    }
     makeHistory();
     startClientState(AppState::STATE_UNTRACKED);
     initializeCommandParser();
@@ -38,9 +40,9 @@ void CLI::run(std::string username, std::string ip, int port) {
     clientThread.join();
 }
 
-void CLI::makeConnection(std::string username, std::string ip, int port) {
+bool CLI::makeConnection(std::string username, std::string ip, int port) {
     connection = std::make_shared<Connection>(Connection());
-    connection->connectToServer(username, ip, port);
+    return connection->connectToServer(username, ip, port);
 }
 
 void CLI::makeHistory() {

--- a/client/CLI.hpp
+++ b/client/CLI.hpp
@@ -21,7 +21,7 @@ class CLI : public ThreadOwner, public std::enable_shared_from_this<CLI> {
     std::thread serverThread;
     std::thread clientThread;
 
-    void makeConnection(std::string username, std::string ip, int port);
+    bool makeConnection(std::string username, std::string ip, int port);
     void makeHistory();
     void startClientState(AppState state);
     void printPrompt();

--- a/client/ClientMonitor.cpp
+++ b/client/ClientMonitor.cpp
@@ -38,11 +38,16 @@ void ClientMonitor::run(std::string sync_dir) {
        clientState->setUntrackedIfNotClosing(); 
     }
 
-    while (clientState->get() == AppState::STATE_ACTIVE) {
-        bytesRead = read(inotifyFd, buffer, EVENT_BUF_LEN); 
-        if (bytesRead > 0) {
-            processEventBuffer(buffer, bytesRead);
+    try {
+        while (clientState->get() == AppState::STATE_ACTIVE) {
+            bytesRead = read(inotifyFd, buffer, EVENT_BUF_LEN); 
+            if (bytesRead > 0) {
+                processEventBuffer(buffer, bytesRead);
+            }
         }
+    } catch (BrokenPipe) {
+        close(inotifyFd);
+        return;
     }
 
     close(inotifyFd);

--- a/client/Connection.cpp
+++ b/client/Connection.cpp
@@ -251,12 +251,17 @@ std::optional<FileOperation> Connection::syncRead() {
     return operation;
 }
 
-FileOperation Connection::syncProcessRead() {
+std::optional<FileOperation> Connection::syncProcessRead() {
     FileId fileId;
     FileOpType fileOpType;
 
     fileOpType = receiveFileOperation(readSock);
     sendOk(readSock);
+
+    if (fileOpType == FileOpType::VOID_OP) {
+        sendOk(readSock);
+        return std::nullopt;
+    }
 
     fileId = receiveFileId(readSock);
     sendOk(readSock);

--- a/client/Connection.hpp
+++ b/client/Connection.hpp
@@ -22,7 +22,7 @@ private:
     void sendDelete(std::filesystem::path target);
 
     void setReadConnection();
-    FileOperation syncProcessRead();
+    std::optional<FileOperation> syncProcessRead();
     void syncReadChange(FileId &fileId);
     void syncReadDelete(FileId &fileId);
     FileOperation makeFileOperation(FileId &fileId, FileOpType &fileOpType);

--- a/client/Connection.hpp
+++ b/client/Connection.hpp
@@ -16,7 +16,7 @@ private:
     int writeSock = -1;
 
     void createSocket(int &socketDescr, std::string ip, int port);
-    void authenticate(int &socketDescr, std::string username);
+    bool authenticate(int &socketDescr, std::string username);
     void setWriteConnection(int &socketDescr);
     void sendChange(std::filesystem::path target);
     void sendDelete(std::filesystem::path target);
@@ -28,7 +28,7 @@ private:
     FileOperation makeFileOperation(FileId &fileId, FileOpType &fileOpType);
 
 public:
-    void connectToServer(std::string username, std::string ip, int port);
+    bool connectToServer(std::string username, std::string ip, int port);
     void upload(std::filesystem::path filepath);
     void download(std::filesystem::path filepath);
     void delete_(std::filesystem::path filepath);

--- a/client/ServerMonitor.cpp
+++ b/client/ServerMonitor.cpp
@@ -19,13 +19,17 @@ ServerMonitor::ServerMonitor(
 }
 
 void ServerMonitor::run() {
-    while (clientState->get() == AppState::STATE_ACTIVE) {
-        std::optional<FileOperation> operation = connection->syncRead();
+    try {
+        while (clientState->get() == AppState::STATE_ACTIVE) {
+            std::optional<FileOperation> operation = connection->syncRead();
 
-        if (operation.has_value()) {
-            history->pushEvent(operation.value());             
-            applyTempIfContentUpdate(operation.value());
+            if (operation.has_value()) {
+                history->pushEvent(operation.value());             
+                applyTempIfContentUpdate(operation.value());
+            }
         }
+    } catch (BrokenPipe) {
+        return;
     }
 }
 

--- a/common/Messages.cpp
+++ b/common/Messages.cpp
@@ -91,6 +91,8 @@ void printMsg(Message *msg) {
 template <typename T>
 T receivePayload(int sock_fd, MsgType expectedType) {
     Message reply = receiveMessage(sock_fd);
+    if (reply.type == MsgType::MSG_ERROR)
+        throw ErrorReply(std::string(reply.payload, reply.len));
     if (reply.type != expectedType)
         throw UnexpectedMsgType(expectedType, reply.type);
     T value;

--- a/common/Messages.hpp
+++ b/common/Messages.hpp
@@ -50,7 +50,7 @@ typedef struct {
     char filename[MAX_FILENAME];
 } FileId;
 
-enum class FileOpType : u_int8_t { FILE_MODIFY, FILE_DELETE, FILE_MOVE };
+enum class FileOpType : u_int8_t { FILE_MODIFY, FILE_DELETE, FILE_MOVE, VOID_OP };
 
 // Struct to identify a file operation
 typedef struct {

--- a/server/DeviceManager.cpp
+++ b/server/DeviceManager.cpp
@@ -1,13 +1,19 @@
 #include "DeviceManager.hpp"
 #include <iostream>
 
-DeviceManager::DeviceManager(std::string username) {
+DeviceManager::DeviceManager(std::string username, int maxDevices) {
     this->username = username;
+    this->maxDevices = maxDevices;
 }
 
 Device& DeviceManager::registerDevice() {
     // Locking to ensure consistency when registering a device
     std::lock_guard<std::mutex> lock(mutex);
+
+    if (maxDevices >= 0 and devices.size() >= maxDevices) {
+        throw TooManyDevices(maxDevices);
+    }
+
     Device device = {
         .id=deviceId,
         .numConnections=0,

--- a/server/DeviceManager.hpp
+++ b/server/DeviceManager.hpp
@@ -25,15 +25,17 @@ class TooManyDevices : public std::exception {
     const char* what() const throw() { return msg.c_str(); }
 };
 
+
 // Manage devices of a single user
 class DeviceManager {
     private:
         int deviceId = 1; // Next deviceId to be assigned. Must start at 1.
-        int maxDevices;
+        int maxDevices; // Maximum number of devices that can be connected at the same time. Set to -1 to disable the limit
         std::string username;
         std::map<int, Device> devices;
         std::mutex mutex;   
     public:
+        // DeviceManager for the given user. Set maxDevices to -1 to remove the limit
         DeviceManager(std::string username, int maxDevices=-1);
         // Register a new device for the user and returns a reference to it. The returned device is 
         // guaranteed to have a unique ID for that user.

--- a/server/DeviceManager.hpp
+++ b/server/DeviceManager.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <map>
+#include <stdexcept>
 #include "SyncQueue.hpp"
 
 struct Device {
@@ -10,15 +11,30 @@ struct Device {
     SyncQueue* queue;
 };
 
+
+class TooManyDevices : public std::exception {
+   private:
+    int maxDevices;
+    std::string msg;
+   public:
+    TooManyDevices(int maxDevices) {
+        this->maxDevices = maxDevices;
+        msg = "User can only connect up to " + std::to_string(maxDevices) + " devices at the same time";
+    };
+
+    const char* what() const throw() { return msg.c_str(); }
+};
+
 // Manage devices of a single user
 class DeviceManager {
     private:
         int deviceId = 1; // Next deviceId to be assigned. Must start at 1.
+        int maxDevices;
         std::string username;
         std::map<int, Device> devices;
         std::mutex mutex;   
     public:
-        DeviceManager(std::string username);
+        DeviceManager(std::string username, int maxDevices=-1);
         // Register a new device for the user and returns a reference to it. The returned device is 
         // guaranteed to have a unique ID for that user.
         Device& registerDevice();

--- a/server/SyncQueue.hpp
+++ b/server/SyncQueue.hpp
@@ -5,6 +5,7 @@
 #include <queue>
 #include <condition_variable>
 #include <semaphore.h>
+#include <optional>
 #include "Messages.hpp"
 
 
@@ -13,12 +14,11 @@ class SyncQueue {
         std::queue<FileOperation> opQueue;
         std::mutex mutex;
         std::condition_variable hasOperation;
-        sem_t sem;
-
     public:
         SyncQueue();
         // Pushes a FileOperation into the queue
         void push(FileOperation fp);
         // Tries to get a FileOperation from the Queue. Blocks until an operation is available
         FileOperation get();
+        std::optional<FileOperation> get(int timeoutMs);
 };

--- a/server/SyncQueue.hpp
+++ b/server/SyncQueue.hpp
@@ -9,6 +9,7 @@
 #include "Messages.hpp"
 
 
+// Atomic queue for FileOperations.
 class SyncQueue {
     private:
         std::queue<FileOperation> opQueue;
@@ -20,5 +21,7 @@ class SyncQueue {
         void push(FileOperation fp);
         // Tries to get a FileOperation from the Queue. Blocks until an operation is available
         FileOperation get();
+        // Tries to get a FileOperation from the Queue. Blocks at most timeoutMs miliseconds.
+        // If no operation is available in the given time, return an empty optional.
         std::optional<FileOperation> get(int timeoutMs);
 };

--- a/server/handlers/SyncServerToClientHandler.cpp
+++ b/server/handlers/SyncServerToClientHandler.cpp
@@ -5,6 +5,8 @@
 #include "Messages.hpp"
 #include "utils.hpp"
 
+#define FILE_OP_TIMEOUT_MS 500
+
 SyncServerToClientHandler::SyncServerToClientHandler(std::string username, int clientSocket, Device &device) {
     this->clientSocket = clientSocket;
     this->username = username;
@@ -16,7 +18,7 @@ void SyncServerToClientHandler::run(){
     sendOk(clientSocket);
 
     while (true) {
-        std::optional<FileOperation> optionalOp = device.queue->get(1000);
+        std::optional<FileOperation> optionalOp = device.queue->get(FILE_OP_TIMEOUT_MS);
         
         FileOperation op = optionalOp.value_or((FileOperation){.type=FileOpType::VOID_OP, .filenameSize=0, .filename=""});
         std::string filename(op.filename, op.filenameSize);

--- a/server/handlers/SyncServerToClientHandler.hpp
+++ b/server/handlers/SyncServerToClientHandler.hpp
@@ -12,6 +12,7 @@ class SyncServerToClientHandler : public Handler {
         void handleFileModify(std::string filename);
         void handleFileDelete(std::string filename);
         void handleFileMove();
+        void handleVoidOp();
     public:
         SyncServerToClientHandler(std::string username, int clientSocket, Device &device);
         void run();


### PR DESCRIPTION
Ajustei o código para corrigir os seguintes problemas:

1. **Adicionado controle de máximo de dispositivos conectados por usuário:** Agora o sistema verifica a cada conexão se o usuário já atingiu a quantidade máxima de dispositivos e nega novas conexões.
2. **Cliente entre em loop infinito quando o servidor cai:** Agora o cliente não entra em um loop infinito exibindo uma mensagem de erro e nem encerra inesperadamente quando o servidor cai. O get_sync_dir ainda não está reestabelecendo as conexões com o servidor, mas como a lógica dessa parte vai ter que ser alterada de qualquer modo na etapa 2, não me preocupei em fazer esse ajuste